### PR TITLE
Completely disable "website is now full screen" message

### DIFF
--- a/user.js
+++ b/user.js
@@ -214,7 +214,7 @@ user_pref("browser.privatebrowsing.enable-new-indicator", false);
 /** FULLSCREEN ***/
 user_pref("full-screen-api.transition-duration.enter", "0 0");
 user_pref("full-screen-api.transition-duration.leave", "0 0");
-user_pref("full-screen-api.warning.delay", 0);
+user_pref("full-screen-api.warning.delay", -1);
 user_pref("full-screen-api.warning.timeout", 0);
 
 /** URL BAR ***/


### PR DESCRIPTION
The user.js file makes it so that the "website is now full screen" message is not shown when you enter fullscreen mode, however if you move your cursor to the top while being in fullscreen mode, it'll still show that popup. Changing "full-screen-api.warning.delay" to -1 fixes this