### PR TITLE
disable privacy-preserving ad measurement

### DIFF
--- a/Securefox.js
+++ b/Securefox.js
@@ -1318,6 +1318,10 @@ user_pref("app.shield.optoutstudies.enabled", false);
 user_pref("app.normandy.enabled", false);
 user_pref("app.normandy.api_url", "");
 
+// PREF: disable Privacy-Preserving Attribution (PPA)
+// [SETTING] Privacy & Security>Website Advertising Preferences>Allow websites to perform privacy-preserving ad measurement
+user_pref("dom.private-attribution.submission.enabled", false);
+
 /******************************************************************************
  * SECTION: CRASH REPORTS                                                    *
 ******************************************************************************/

--- a/user.js
+++ b/user.js
@@ -156,6 +156,7 @@ user_pref("browser.newtabpage.activity-stream.telemetry", false);
 user_pref("app.shield.optoutstudies.enabled", false);
 user_pref("app.normandy.enabled", false);
 user_pref("app.normandy.api_url", "");
+user_pref("dom.private-attribution.submission.enabled", false);
 
 /** CRASH REPORTS ***/
 user_pref("breakpad.reportURL", "");


### PR DESCRIPTION
not a feature that most people seem to want, and its enabled by default since firefox 128