### PR TITLE
Improve install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -49,7 +49,7 @@ INSTALLATIONS_TO_CHECK = [
     # windows
     {
         "command": [str(Path("C:/Program Files/Mozilla Firefox/firefox"))],
-        "root": Path(getenv("APPDATA") or "").joinpath("/Mozilla/Firefox/").resolve(),
+        "root": Path(getenv("APPDATA") or "").joinpath("Mozilla/Firefox").resolve(),
     },
     # linux
     {

--- a/install.py
+++ b/install.py
@@ -191,7 +191,10 @@ def list_releases(releases, only_supported=False, add_index=False):
         if not only_supported or (only_supported and supported):
             print(f"{f'[{i}]' if add_index else ''}{'> ' if supported else '  '}{release['name'].ljust(20)}\t\t\tSupported: {','.join(release['supported'])}")
         i+=1
-    
+
+def _press_enter_to_exit(args):
+    if not args.no_wait_for_exit:
+        input("Press ENTER to exit...")
 
 if __name__ == "__main__":
     firefox_version, firefox_root = _get_default_firefox_version_and_root()
@@ -219,6 +222,9 @@ if __name__ == "__main__":
     modes.add_argument("--list-all", action="store_true", default=False, help=f"List all Betterfox releases")
     modes.add_argument("--interactive", "-i", action="store_true", default=False, help=f"Interactively select Betterfox version")
 
+    behaviour = argparser.add_argument_group("Script behaviour")
+    behaviour.add_argument("--no-wait-for-exit", "-nwfe", action="store_true", default=False, help="Disable 'Press ENTER to exit...' and exit immediately"),
+
     args = argparser.parse_args()
 
     releases = _get_releases(args.repository_owner, args.repository_name)
@@ -226,7 +232,7 @@ if __name__ == "__main__":
 
     if args.list or args.list_all:
         list_releases(releases, args.list)
-        input("Press ENTER to exit...")
+        _press_enter_to_exit(args)
         exit()
 
     if not args.no_backup:
@@ -276,6 +282,6 @@ if __name__ == "__main__":
                 userjs_file.write(new_content)
         else:
             print(f"Found no overrides in {args.overrides}")
-    
-    input("Press ENTER to exit...")
+
+    _press_enter_to_exit(args)
 

--- a/install.py
+++ b/install.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from datetime import datetime
 from os import name, getenv
 from json import loads

--- a/install.py
+++ b/install.py
@@ -58,7 +58,11 @@ def _get_firefox_version(bin="firefox"):
         ver_string = check_output([bin, "--version"], encoding="UTF-8")
         return ver_string[ver_string.rindex(" ")+1:].strip()
     except FileNotFoundError:
-        return _get_firefox_version(str(DEFAULT_FIREFOX_INSTALL.joinpath("firefox")))
+        default_path = str(DEFAULT_FIREFOX_INSTALL.joinpath("firefox"))
+        if bin != default_path:  # Avoid infinite recursion
+            return _get_firefox_version(default_path)
+        else:
+            raise Exception("Firefox binary not found. Please ensure Firefox is installed and the path is correct.")
 
 def _get_default_profile_folder():
     config_path = FIREFOX_ROOT.joinpath("profiles.ini")
@@ -124,17 +128,7 @@ def _get_latest_compatible_release(releases):
     for release in releases:
         if firefox_version in release["supported"]:
             return release
-    return None    
-def _get_firefox_version(bin="firefox"):
-    try:
-        ver_string = check_output([bin, "--version"], encoding="UTF-8")
-        return ver_string[ver_string.rindex(" ")+1:].strip()
-    except FileNotFoundError:
-        default_path = str(DEFAULT_FIREFOX_INSTALL.joinpath("firefox"))
-        if bin != default_path:  # Avoid infinite recursion
-            return _get_firefox_version(default_path)
-        else:
-            raise Exception("Firefox binary not found. Please ensure Firefox is installed and the path is correct.")    
+    return None
 
 def backup_profile(src):
     dest = f"{src}-backup-{datetime.today().strftime('%Y-%m-%d-%H-%M-%S')}"


### PR DESCRIPTION
Changes:

- Refactor searching for Firefox installation (tested on Windows 10 and Ubuntu, but verify it please)
- Search also for flatpak version (see #340, tested on Bazzite)
- Add option to disable "Press ENTER to exit..." so it's easier to automate running the script
- Add shebang so the script can be made an executable. (So you can move it eg. to `~/.local/bin/install-betterfox` and launch it simply as `install-betterfox`)

@Denperidge what's your opinion on this?
