### PR TITLE
Add Zen PIP pop-out on tab change override

### DIFF
--- a/zen/user.js
+++ b/zen/user.js
@@ -104,6 +104,9 @@ user_pref("zen.view.experimental-rounded-view", false);
 // Currently bugged if you click to view what's blocked
 //user_pref("zen.urlbar.show-protections-icon", true);
 
+// PREF: Disable the Picture in picture pop-out when changing tabs
+//user_pref("media.videocontrols.picture-in-picture.enable-when-switching-tabs.enabled", false);
+
 /****************************************************************************
  * START: MY OVERRIDES                                                      *
 ****************************************************************************/


### PR DESCRIPTION
In the latest release of Zen, this setting has been turned on by default and can only be changed by the `user.js`
![image](https://github.com/user-attachments/assets/20332793-6183-4641-9ebf-6290e3211af2)

This adds the override needed to disable it.