### PR TITLE
Securefox: network.auth.subresource-http-auth-allow kills TB SoGo calendar subscription

### DIFF
--- a/Securefox.js
+++ b/Securefox.js
@@ -887,11 +887,12 @@ user_pref("signon.privateBrowsingCapture.enabled", false);
 
 // PREF: limit (or disable) HTTP authentication credentials dialogs triggered by sub-resources [FF41+]
 // Hardens against potential credentials phishing.
+// [WARNING] Hardening this pref may prevent you from subscribing to SoGo calendars in Thunderbird 138
 // 0=don't allow sub-resources to open HTTP authentication credentials dialogs
 // 1=don't allow cross-origin sub-resources to open HTTP authentication credentials dialogs
 // 2=allow sub-resources to open HTTP authentication credentials dialogs (default)
 // [1] https://www.fxsitecompat.com/en-CA/docs/2015/http-auth-dialog-can-no-longer-be-triggered-by-cross-origin-resources/
-user_pref("network.auth.subresource-http-auth-allow", 1); //This will prevent you from subscribing to SoGo calendars in TB 138
+user_pref("network.auth.subresource-http-auth-allow", 1);
 
 // PREF: prevent password truncation when submitting form data
 // [1] https://www.ghacks.net/2020/05/18/firefox-77-wont-truncate-text-exceeding-max-length-to-address-password-pasting-issues/

--- a/Securefox.js
+++ b/Securefox.js
@@ -891,7 +891,7 @@ user_pref("signon.privateBrowsingCapture.enabled", false);
 // 1=don't allow cross-origin sub-resources to open HTTP authentication credentials dialogs
 // 2=allow sub-resources to open HTTP authentication credentials dialogs (default)
 // [1] https://www.fxsitecompat.com/en-CA/docs/2015/http-auth-dialog-can-no-longer-be-triggered-by-cross-origin-resources/
-user_pref("network.auth.subresource-http-auth-allow", 1);
+user_pref("network.auth.subresource-http-auth-allow", 1); //This will prevent you from subscribing to SoGo calendars in TB 138
 
 // PREF: prevent password truncation when submitting form data
 // [1] https://www.ghacks.net/2020/05/18/firefox-77-wont-truncate-text-exceeding-max-length-to-address-password-pasting-issues/


### PR DESCRIPTION
Setting "network.auth.subresource-http-auth-allow" to 1 will effectively prevent you from subscribing to SoGo calendars in TB 138.