### PR TITLE
Remove "network.predictor.enable-prefetch"

### DIFF
--- a/user.js
+++ b/user.js
@@ -54,7 +54,6 @@ user_pref("browser.urlbar.speculativeConnect.enabled", false);
 user_pref("browser.places.speculativeConnect.enabled", false);
 user_pref("network.prefetch-next", false);
 user_pref("network.predictor.enabled", false);
-user_pref("network.predictor.enable-prefetch", false);
 
 /** EXPERIMENTAL ***/
 user_pref("layout.css.grid-template-masonry-value.enabled", true);


### PR DESCRIPTION
It is enabled by default in FF48+ and also inactive in securefox.js