### PR TITLE
Allow Firefox installed as non-admin

### DIFF
--- a/install.py
+++ b/install.py
@@ -51,6 +51,10 @@ INSTALLATIONS_TO_CHECK = [
         "command": [str(Path("C:/Program Files/Mozilla Firefox/firefox"))],
         "root": Path(getenv("APPDATA") or "").joinpath("Mozilla/Firefox").resolve(),
     },
+    {
+        "command": [str(Path(getenv("LOCALAPPDATA") or "").joinpath("Mozilla Firefox/firefox").resolve())],
+        "root": Path(getenv("APPDATA") or "").joinpath("Mozilla/Firefox").resolve(),
+    },
     # linux
     {
         "command": ["firefox"],


### PR DESCRIPTION
Add another option for Firefox on Windows installed to `%LOCALAPPDATA%`.