### PR TITLE
install.py: add support for macOS

### DIFF
--- a/install.py
+++ b/install.py
@@ -65,6 +65,11 @@ INSTALLATIONS_TO_CHECK = [
         "command": ["flatpak", "run", "org.mozilla.firefox"],
         "root": Path.home().joinpath(".var/app/org.mozilla.firefox/.mozilla/firefox").absolute(),
     },
+    # macOS
+    {
+        "command": ["/Applications/Firefox.app/Contents/MacOS/firefox"],
+        "root": Path.home().joinpath("Library/Application Support/Firefox").absolute(),
+    },
 ]
 
 


### PR DESCRIPTION
I just tested it with `python install.py` and w/ `--list`+`--list-all`, and it appears to work just fine.

I'm on macOS, so if there's any other commands you would want me to test, I'm happy to do so!