### PR TITLE
Enable WebRender layer compositor

### DIFF
--- a/user.js
+++ b/user.js
@@ -237,4 +237,3 @@ user_pref("layout.word_select.eat_space_to_next_word", false);
  * END: BETTERFOX                                                           *
 ****************************************************************************/
 
-


### PR DESCRIPTION
This change adds the `gfx.webrender.layer-compositor` preference to `user.js` and enables Firefox’s newer layer compositor.

References:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1945683
- https://www.reddit.com/r/firefox/comments/1p58qre/firefox_is_getting_ready_to_make_youtube_fast
- https://www.ghacks.net/2025/11/24/these-two-tweaks-should-improve-firefoxs-performance-on-youtube-significantly