### PR TITLE
Change 'Block AI enhancements' parameter to 'blocked'

### DIFF
--- a/user.js
+++ b/user.js
@@ -151,6 +151,11 @@ user_pref("browser.privateWindowSeparation.enabled", false); // WINDOWS
 
 /** AI ***/
 user_pref("browser.ai.control.default", "blocked");
+user_pref("browser.ai.control.linkPreviewKeyPoints", "blocked");
+user_pref("browser.ai.control.pdfjsAltText", "blocked");
+user_pref("browser.ai.control.sidebarChatbot", "blocked");
+user_pref("browser.ai.control.smartTabGroups", "blocked");
+user_pref("browser.ai.control.translations", "blocked");
 user_pref("browser.ml.enable", false);
 user_pref("browser.ml.chat.enabled", false);
 user_pref("browser.ml.chat.menu", false);


### PR DESCRIPTION
This parameter changes AI Control to “Blocked.” Essentially, if we keep only this parameter, the browser will disable AI completely.
<img width="1614" height="656" alt="image" src="https://github.com/user-attachments/assets/d136a3fb-a3ab-4eda-8176-818a33376c74" />
