### PR TITLE
Add encoding parameter to profile path detection

### DIFF
--- a/install.py
+++ b/install.py
@@ -99,7 +99,7 @@ def _get_default_profile_folder(firefox_root):
     print(f"Reading {config_path}...")
 
     config_parser = ConfigParser(strict=False)
-    config_parser.read(config_path)
+    config_parser.read(config_path, encoding = "utf8")
 
     path = None
     for section in config_parser.sections():


### PR DESCRIPTION
It seems that new profile system of Firefox allows non-ascii symbols in the profile folder name.

<img width="162" height="38" alt="{A75F68D5-FF94-476C-8A64-0C8002ED6107}" src="https://github.com/user-attachments/assets/d749f5db-344f-4d5e-9e2d-1eb725c3452b" />

This tiny PR forces `install.py` to use UTF8 for the folder name.

PS: this is a "copy" of my previous PR closed by myself. Too many personal commits leaked in previous PR so I had to clean and rearrange my fork.