### PR TITLE
Fixed install.py ignore Waterfox user.js unless requested

### DIFF
--- a/install.py
+++ b/install.py
@@ -177,6 +177,8 @@ def extract_betterfox(data, profile_folder):
     for file in zipfile.filelist:
         if "/zen/" in file.filename and not args.zen:
             continue
+        if "/waterfox/" in file.filename and not args.waterfox:
+            continue
         if file.filename.endswith("user.js"):
             userjs_zipinfo = file
             userjs_zipinfo.filename = Path(userjs_zipinfo.filename).name
@@ -217,6 +219,7 @@ if __name__ == "__main__":
     )
     argparser.add_argument("--overrides", "-o", default=default_profile_folder.joinpath("user-overrides.js"), help="if the provided file exists, add overrides to user.js. Defaults to " + str(default_profile_folder.joinpath("user-overrides.js"))),
     argparser.add_argument("--zen", "-z", action="store_true", default=False, help="Install user.js for the Zen browser instead. Defaults to False"),
+    argparser.add_argument("--waterfox", "-w", action="store_true", default=False, help="Install user.js for the Waterfox browser instead. Defaults to False"),
     
     
     advanced = argparser.add_argument_group("Advanced")


### PR DESCRIPTION
When running the install.py script, the waterfox\user.js would be used instead of the default version. This changes the install.py script to ignore the Waterfox version unless requested.